### PR TITLE
Created modified Dockerfile for ARM64 build

### DIFF
--- a/arm64.Dockerfile
+++ b/arm64.Dockerfile
@@ -1,0 +1,171 @@
+FROM --platform=linux/arm64 ubuntu:20.04
+
+# Set to false to skip downloading the AMP cache which is used for faster upgrades.
+ARG CACHE_AMP_UPGRADE=true
+
+ENV UID=1000
+ENV GID=1000
+ENV TZ=Etc/UTC
+ENV PORT=8080
+ENV USERNAME=admin
+ENV PASSWORD=password
+ENV LICENCE=notset
+ENV MODULE=ADS
+
+ENV AMP_SUPPORT_LEVEL=UNSUPPORTED
+ENV AMP_SUPPORT_TOKEN=AST0/MTAD
+ENV AMP_SUPPORT_TAGS="nosupport docker community unofficial unraid"
+ENV AMP_SUPPORT_URL="https://github.com/MitchTalmadge/AMP-dockerized/"
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Initialize
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    jq \
+    sed \
+    tzdata \
+    wget && \
+    apt-get -y clean && \
+    apt-get -y autoremove --purge && \
+    rm -rf \
+    /tmp/* \
+    /var/lib/apt/lists/* \
+    /var/tmp/*
+
+
+# Configure Locales
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends locales && \
+    apt-get -y clean && \
+    apt-get -y autoremove --purge && \
+    rm -rf \
+    /tmp/* \
+    /var/lib/apt/lists/* \
+    /var/tmp/*
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
+    dpkg-reconfigure --frontend=noninteractive locales && \
+    update-locale LANG=en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+
+# Add Mono apt source
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    apt-transport-https \
+    dirmngr \
+    software-properties-common \
+    gnupg \
+    ca-certificates && \
+    apt-get -y clean && \
+    apt-get -y autoremove --purge && \
+    rm -rf \
+    /tmp/* \
+    /var/lib/apt/lists/* \
+    /var/tmp/*
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF && \
+    echo "deb https://download.mono-project.com/repo/ubuntu stable-focal main" | tee /etc/apt/sources.list.d/mono-official-stable.list
+
+
+# Install Mono Certificates
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    ca-certificates-mono && \
+    apt-get -y clean && \
+    apt-get -y autoremove --purge && \
+    rm -rf \
+    /tmp/* \
+    /var/lib/apt/lists/* \
+    /var/tmp/*
+RUN wget -O /tmp/cacert.pem https://curl.haxx.se/ca/cacert.pem && \
+    cert-sync /tmp/cacert.pem
+
+
+# Install AMP dependencies
+RUN ls -al /usr/local/bin/
+RUN dpkg --add-architecture arm64 && \
+    apt-get update && \
+    apt-get install -y \
+    # --------------------
+    # Dependencies for AMP:
+    tmux \
+    git \
+    socat \
+    unzip \
+    iputils-ping \
+    procps \
+    # --------------------
+    # Dependencies for Minecraft:
+    openjdk-17-jre-headless \
+    openjdk-11-jre-headless \
+    openjdk-8-jre-headless \
+    # --------------------
+    # Dependencies for srcds (TF2, GMod, ...)
+    #lib32gcc1 \
+    #lib32stdc++6 \
+    #lib32z1 \
+    #libbz2-1.0:arm64 \
+    #libcurl3-gnutls:arm64 \
+    #libcurl4 \
+    #libncurses5:arm64 \
+    #libsdl2-2.0-0 \
+    #libsdl2-2.0-0:arm64 \
+    #libtinfo5:arm64 \
+    # --------------------
+    # Dependencies for Factorio:
+    xz-utils \
+    # --------------------
+    && \
+    apt-get -y clean && \
+    apt-get -y autoremove --purge && \
+    rm -rf \
+    /tmp/* \
+    /var/lib/apt/lists/* \
+    /var/tmp/*
+
+# Set Java default
+RUN update-alternatives --set java /usr/lib/jvm/java-17-openjdk-arm64/bin/java
+
+# Manually install ampinstmgr by extracting it from the deb package.
+# Docker doesn't have systemctl and other things that AMP's deb postinst expects,
+# so we can't use apt to install ampinstmgr.
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    software-properties-common \
+    dirmngr \
+    apt-transport-https && \
+    # Add CubeCoders repository and key
+    apt-key adv --fetch-keys http://repo.cubecoders.com/archive.key && \
+    apt-add-repository "deb http://repo.cubecoders.com/aarch64/ debian/" && \
+    apt-get update && \
+    # Just download (don't actually install) ampinstmgr
+    apt-get install -y --no-install-recommends --download-only ampinstmgr && \
+    # Extract ampinstmgr from downloaded package
+    mkdir -p /tmp/ampinstmgr && \
+    dpkg-deb -x /var/cache/apt/archives/ampinstmgr_*.deb /tmp/ampinstmgr && \
+    mv /tmp/ampinstmgr/opt/cubecoders/amp/ampinstmgr /usr/local/bin/ampinstmgr && \
+    apt-get -y clean && \
+    apt-get -y autoremove --purge && \
+    rm -rf \
+    /tmp/* \
+    /var/lib/apt/lists/* \
+    /var/tmp/*
+
+# Get the latest AMP Core to pre-cache upgrades.
+RUN if [ "$CACHE_AMP_UPGRADE" = "true" ]; then \
+    echo "Pre-caching AMP Upgrade..." && \
+    wget https://cubecoders.com/AMPVersions.json -O /tmp/AMPVersions.json && \
+    wget https://cubecoders.com/Downloads/AMP_Latest.zip -O /opt/AMPCache-$(cat /tmp/AMPVersions.json | jq -r '.AMPCore' | sed -e 's/\.//g').zip; \
+    else echo "Skipping AMP Upgrade Pre-cache."; \
+    fi
+
+
+# Set up environment
+COPY entrypoint /opt/entrypoint
+RUN chmod -R +x /opt/entrypoint
+
+VOLUME ["/home/amp/.ampdata"]
+
+ENTRYPOINT ["/opt/entrypoint/main.sh"]


### PR DESCRIPTION
Removed srcds dependencies as they don't have arm64 support.
Replaced amd64 Java with arm64
Using buildx build was successful but unable to create AMP instance due to failure of fetching arm64 binary for amp.

Logs:
----------------------,
Starting AMP-Dockerized...,
----------------------,
Note: This is an UNOFFICIAL IMAGE for CubeCoders AMP. This was created by the community, NOT CubeCoders.,
Please, DO NOT contact CubeCoders (Discord or otherwise) for technical support when using this image.,
They do not support nor endorse this image and will not help you.,
Instead, please direct support requests to https://github.com/MitchTalmadge/AMP-dockerized/issues.,
We are happy to help you there!,
Thank you!!,
----------------------,
,
Copying AMP Core...,
Ensuring AMP user exists...,
Adding group `amp' (GID 124) ...,
Done.,
Adding system user `amp' (UID 1001) ...,
Adding new user `amp' (UID 1001) with group `amp' ...,
Not creating home directory `/home/amp'.,
Ensuring correct file permissions...,
Setting timezone from TZ env var...,
,
Current default time zone: 'Asia/Kolkata',
Local time is now:      Wed Jan  5 10:43:34 IST 2022.,
Universal Time is now:  Wed Jan  5 05:13:34 UTC 2022.,
,
Making sure Main instance exists...,
Creating Main instance... (This can take a while),
[Info] AMP Instance Manager v2.3.0.8 built 21/12/2021 17:18,
[Info] Release spec: Release (aarch64) - built by CUBECODERS/buildbot on CCL-DEV,
[Info] Testing internet connection...,
[Info] Checking licence key...,
[Info] Licence Type:  AMP Professional,
[Info] Current Usage: 1,
[Info] Creating Instance: 'Main',
[Info] Performing Step: Creating Environment,
[Activity] Audit: Unknown/None [CreateInstance] Created instance Main using ADS module on port 8080.,
[Info] Performing Step: Downloading AMP,
[Info] Using cached archive: /home/amp/.ampdata/instances/AMPCache-2308.zip,
[Info] Performing Step: Unpacking,
[Error] Download or unpack failed. Please check your network connection and try again.,
[Error] AMP_Linux_aarch64 does not exist!,
[Info] Performing Step: Failed,
[Info] Instance creation failed. The core archive failed to download or unpack,
Setting all instances to use MainLine updates...,
Upgrading Instances...,
[Info] AMP Instance Manager v2.3.0.8 built 21/12/2021 17:18,
[Info] Release spec: Release (aarch64) - built by CUBECODERS/buildbot on CCL-DEV,
[Info] There are no instances to update.,
Ensuring Main Instance will Start on Boot...,
Starting AMP...,
[Info] AMP Instance Manager v2.3.0.8 built 21/12/2021 17:18,
[Info] Release spec: Release (aarch64) - built by CUBECODERS/buildbot on CCL-DEV,
[Info] No AMP instances are currently set to start automatically on boot.,
AMP Started.,
----------------------,
NOTICE: Java 17 is now the default in this image. Java 16 has been removed in preference of Java 17, which is LTS.,
Use the Java Configuration section in the AMP Web UI to select a specific version. Otherwise, Java 17 will be used automatically.,
----------------------,
Entrypoint Sleeping. Logs can be viewed through AMP web UI or at ampdata/instances/Main/AMP_Logs