### PR TITLE
Adapt Dockerfile and build.yml to enable arm64 builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [amd64]
+        arch: [amd64,arm64]
     steps:
       - name: "Checkout Git Repo"
         uses: actions/checkout@v2

--- a/entrypoint/main.sh
+++ b/entrypoint/main.sh
@@ -93,7 +93,7 @@ su ${APP_USER} --command "ampinstmgr UpgradeAll" | grep --line-buffered -v -E '\
 
 # Set Main instance to start on boot if not already.
 echo "Ensuring Main Instance will Start on Boot..."
-su ${APP_USER} --command "ampinstmgr ShowInstanceInfo Main | grep \"Start on Boot\" | grep \"No\" && ampinstmgr SetStartBoot Main || true"
+su ${APP_USER} --command "ampinstmgr ShowInstanceInfo Main | grep \"Start on Boot\" | grep \"No\" && ampinstmgr SetStartBoot Main yes || true" 
 
 # Startup
 echo "Starting AMP..."

--- a/example-configs/valheim/portainer/docker-compose.yml
+++ b/example-configs/valheim/portainer/docker-compose.yml
@@ -1,0 +1,20 @@
+# This has minor adjustments to get working on a Portaienr cluster
+---
+version: "3.6" # this must be 3.6
+services:
+  amp:
+    image: mitchtalmadge/amp-dockerized:latest
+    mac_address: 02:42:AC:XX:XX:XX #generated
+    container_name: amp
+    environment:
+      - UID=1000 # change to your portainer uid
+      - GID=1000 # change to your portainer gid
+      - TZ=Etc/UTC
+      - LICENCE=<licence key>
+      - MODULE=ADS # only tested with ADS
+    volumes:
+      - /etc/amp/:/home/amp/.ampdata # needs to be ownable by portainer uid
+    ports:
+      - 8080:8080
+      - 5678-5680:5678-5680/udp # valheim - amp defaults to 2456-2458
+    restart: unless-stopped


### PR DESCRIPTION
The dockerfile is what makes the arm64 image work as long as you build it with --platform linux/amd64,linux/arm64 (if building manually). 

The singular change in build.yml tells GH to make both automatically.

I might not have done this in the absolute best/most efficient way, but I think it's pretty clean and it works from my testing.