### PR TITLE
add name to artifact download

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -16,6 +16,7 @@ jobs:
       - name: "Download Docker Image Artifact"
         uses: actions/download-artifact@v2
         with:
+          name: "image"
           path: /tmp
       - name: "Load Docker Image"
         run: |


### PR DESCRIPTION
this should prevent the extra "image" directory from being created, which is blocking the deploy script from seeing the image with its hardcoded path

see https://github.com/actions/download-artifact#download-path-output

I took a look at the exact failure in the most recent deployment attempt and caught a file path mismatch, technically either this change OR changing the load target path on line 23 to /tmp/image/docker-image.tar should work

![CleanShot 2023-07-06 at 14 36 53@2x](https://github.com/MitchTalmadge/AMP-dockerized/assets/31298266/b1a1a432-c112-458b-b5df-716fdb265a11)
