### PR TITLE
Add python3-venv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,7 @@ ARG WINEXVFB="\
     libwine \
     libwine:i386 \
     python3 \
+    python3-venv \
     wine \
     wine32 \
     wine64 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -120,6 +120,7 @@ ARG WINEXVFB="\
     libwine:i386 \
     python3 \
     python3-venv \
+    cabextract \
     wine \
     wine32 \
     wine64 \


### PR DESCRIPTION
This adds support for the latest Python3 changes that require virtual environments and in turn, GatekeeperV2 support.