### PR TITLE
Auto-build on new ampinstmgr releases, faster CI builds, migration to new CubeCoders repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,24 +21,73 @@ jobs:
     strategy:
       matrix:
         arch: [amd64,arm64]
+    env:
+      # Set the DOCKERHUB_IMAGE repository variable to push elsewhere (e.g. in forks).
+      IMAGE: ${{ vars.DOCKERHUB_IMAGE || 'mitchtalmadge/amp-dockerized' }}
     steps:
       - name: "Checkout Git Repo"
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - name: "Get Latest ampinstmgr Version"
+        # Passed to the build as a build-arg so that the layer cache is busted
+        # whenever CubeCoders releases a new version. Without this, a fully
+        # cached build would keep shipping the previously downloaded ampinstmgr.
+        id: amp_version
+        run: |
+          if [[ "${{ matrix.arch }}" == "arm64" ]]; then
+            URL="https://cdn-repo.c7rs.com/aarch64/debian/Packages"
+          else
+            URL="https://cdn-repo.c7rs.com/debian/Packages"
+          fi
+          VERSION=$(curl -fsSL "${URL}" | awk '
+            /^Package: ampinstmgr$/ { found=1; next }
+            /^Package:/ { found=0 }
+            found && /^Version:/ { print $2 }
+          ' | sort -V | tail -n 1)
+          if [[ -z "${VERSION}" ]]; then
+            echo "::error::Could not determine the latest ampinstmgr version from the CubeCoders repository."
+            exit 1
+          fi
+          echo "Latest ampinstmgr version: ${VERSION}"
+          echo "VERSION=${VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: "Set up Docker Buildx"
         uses: docker/setup-buildx-action@v3
+      - name: "Login to Docker Hub"
+        if: ${{ inputs.for_deploy == true }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: "Build Docker Image"
-        uses: docker/build-push-action@v4
+        id: build
+        uses: docker/build-push-action@v6
         with:
           context: .
           platforms: linux/${{ matrix.arch }}
-          tags: amp-dockerized:latest
-          outputs: type=docker,dest=/tmp/docker-image-${{ matrix.arch }}.tar
-      - name: "Upload Docker Image Artifact"
+          provenance: false
+          build-args: |
+            AMP_VERSION=${{ steps.amp_version.outputs.VERSION }}
+          cache-from: type=gha,scope=build-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=build-${{ matrix.arch }}
+          # When deploying, push the image by digest; the deploy workflow then
+          # stitches the per-arch digests into multi-arch manifests without the
+          # image ever being exported to a tar file.
+          outputs: ${{ inputs.for_deploy == true && format('type=image,name={0},push-by-digest=true,name-canonical=true,push=true', env.IMAGE) || '' }}
+
+      - name: "Export Digest"
+        if: ${{ inputs.for_deploy == true }}
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: "Upload Digest Artifact"
         if: ${{ inputs.for_deploy == true }}
         uses: actions/upload-artifact@v4
         with:
-          name: image-${{ matrix.arch }}
-          path: /tmp/docker-image-${{ matrix.arch }}.tar
+          name: digests-${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/check-amp-update.yml
+++ b/.github/workflows/check-amp-update.yml
@@ -1,0 +1,213 @@
+name: "Check AMP Update"
+
+# Checks the CubeCoders APT repository daily for a new version of ampinstmgr.
+# When both the amd64 and aarch64 repositories serve a version newer than the
+# last one built, this workflow dispatches "Deploy Production" with the next
+# release tag, waits for it to succeed, then creates a matching GitHub
+# release. The last-built version is read from the release history: a marker
+# comment in the body of the newest automated release, falling back to
+# release titles like "v26 - AMP 2.7.2". No extra state or PAT is required
+# (the GITHUB_TOKEN cannot write repository variables). If the deploy fails,
+# no release is created and the next scheduled run will try again.
+
+on:
+  schedule:
+    - cron: "17 4 * * *"
+  workflow_dispatch:
+    inputs:
+      force:
+        description: "Build and release even if no new version was detected"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write # Create releases and tags
+  actions: write # Dispatch the deploy workflow
+
+concurrency:
+  group: check-amp-update
+  cancel-in-progress: false
+
+jobs:
+  check:
+    name: "Check for New Version"
+    runs-on: ubuntu-latest
+    outputs:
+      should_build: ${{ steps.compare.outputs.SHOULD_BUILD }}
+      version: ${{ steps.upstream.outputs.VERSION }}
+      previous_version: ${{ steps.compare.outputs.PREVIOUS_VERSION }}
+    steps:
+      - name: "Get Latest ampinstmgr Version"
+        id: upstream
+        run: |
+          get_version() {
+            curl -fsSL "$1" | awk '
+              /^Package: ampinstmgr$/ { found=1; next }
+              /^Package:/ { found=0 }
+              found && /^Version:/ { print $2 }
+            ' | sort -V | tail -n 1
+          }
+          AMD64_VERSION=$(get_version "https://cdn-repo.c7rs.com/debian/Packages")
+          ARM64_VERSION=$(get_version "https://cdn-repo.c7rs.com/aarch64/debian/Packages")
+          echo "amd64: ${AMD64_VERSION:-<not found>} | arm64: ${ARM64_VERSION:-<not found>}"
+          if [[ -z "${AMD64_VERSION}" || -z "${ARM64_VERSION}" ]]; then
+            echo "::error::Could not determine the latest ampinstmgr version from the CubeCoders repository."
+            exit 1
+          fi
+          if [[ "${AMD64_VERSION}" != "${ARM64_VERSION}" ]]; then
+            echo "::notice::The amd64 (${AMD64_VERSION}) and arm64 (${ARM64_VERSION}) repositories are out of sync. Skipping until both serve the same version."
+            echo "VERSION=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "VERSION=${AMD64_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: "Get Last Built Version"
+        id: last
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          # The newest release carrying a version marker in its body wins.
+          # Releases created by this workflow always contain the marker.
+          LAST_VERSION=$(gh api --paginate "repos/${GH_REPO}/releases" --jq '.[].body // ""' \
+            | grep -oE 'ampinstmgr-version: [0-9][0-9A-Za-z.+~-]*' | head -n 1 | awk '{print $2}')
+          if [[ -z "${LAST_VERSION}" ]]; then
+            # No marker anywhere (e.g. before the first automated release):
+            # fall back to manually written titles like "v26 - AMP 2.7.2".
+            LAST_VERSION=$(gh api --paginate "repos/${GH_REPO}/releases" --jq '.[].name // ""' \
+              | grep -oE -e '- AMP [0-9][0-9A-Za-z.+~-]*$' | head -n 1 | awk '{print $3}')
+          fi
+          echo "Last built version: ${LAST_VERSION:-<unknown>}"
+          echo "LAST_VERSION=${LAST_VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: "Compare With Last Built Version"
+        id: compare
+        env:
+          NEW_VERSION: ${{ steps.upstream.outputs.VERSION }}
+          LAST_VERSION: ${{ steps.last.outputs.LAST_VERSION }}
+          FORCE: ${{ inputs.force }}
+        run: |
+          echo "PREVIOUS_VERSION=${LAST_VERSION}" >> "$GITHUB_OUTPUT"
+          SHOULD_BUILD=false
+          if [[ -z "${NEW_VERSION}" ]]; then
+            echo "Repositories are out of sync; nothing to do."
+          elif [[ "${FORCE}" == "true" ]]; then
+            echo "Force requested; building ampinstmgr ${NEW_VERSION}."
+            SHOULD_BUILD=true
+          elif [[ -z "${LAST_VERSION}" ]]; then
+            echo "No previously built version found in the release history; treating ampinstmgr ${NEW_VERSION} as new."
+            SHOULD_BUILD=true
+          elif dpkg --compare-versions "${NEW_VERSION}" gt "${LAST_VERSION}"; then
+            echo "New ampinstmgr version found: ${LAST_VERSION} -> ${NEW_VERSION}."
+            SHOULD_BUILD=true
+          else
+            echo "Already up to date (last built: ${LAST_VERSION}, upstream: ${NEW_VERSION})."
+          fi
+          echo "SHOULD_BUILD=${SHOULD_BUILD}" >> "$GITHUB_OUTPUT"
+
+  build_and_release:
+    name: "Build and Release"
+    runs-on: ubuntu-latest
+    needs: check
+    if: needs.check.outputs.should_build == 'true'
+    timeout-minutes: 180
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      AMP_VERSION: ${{ needs.check.outputs.version }}
+      PREVIOUS_VERSION: ${{ needs.check.outputs.previous_version }}
+    steps:
+      - name: "Determine Next Release Tag"
+        id: next_tag
+        run: |
+          # Consider both releases and plain git tags: forks (and fresh repos)
+          # may carry v<N> tags without any releases, and the new tag must not
+          # collide with either. When running in a fork, also consider the
+          # parent repository's tags so the numbering stays aligned with
+          # upstream even when the fork's tags have drifted behind.
+          PARENT=$(gh api "repos/${GH_REPO}" --jq '.parent.full_name // empty')
+          [[ -n "${PARENT}" ]] && echo "Fork of ${PARENT}; including its tags."
+          LATEST_NUMBER=$(
+            {
+              gh api --paginate "repos/${GH_REPO}/releases" --jq '.[].tag_name'
+              gh api --paginate "repos/${GH_REPO}/tags" --jq '.[].name'
+              [[ -n "${PARENT}" ]] && gh api --paginate "repos/${PARENT}/tags" --jq '.[].name'
+            } | grep -E '^v[0-9]+$' | sed 's/^v//' | sort -n | tail -n 1)
+          NEXT_TAG="v$(( ${LATEST_NUMBER:-0} + 1 ))"
+          TARGET_SHA=$(gh api "repos/${GH_REPO}/commits/${{ github.ref_name }}" --jq '.sha')
+          echo "Next release: ${NEXT_TAG} (targeting ${TARGET_SHA})"
+          echo "NEXT_TAG=${NEXT_TAG}" >> "$GITHUB_OUTPUT"
+          echo "TARGET_SHA=${TARGET_SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: "Dispatch Deploy Production"
+        id: dispatch
+        env:
+          NEXT_TAG: ${{ steps.next_tag.outputs.NEXT_TAG }}
+        run: |
+          # Small backdate to tolerate clock skew between the runner and GitHub.
+          DISPATCH_TIME=$(date -u -d '60 seconds ago' +%Y-%m-%dT%H:%M:%SZ)
+          gh workflow run deploy-prod.yml --ref "${{ github.ref_name }}" -f tag="${NEXT_TAG}"
+          # Find the run we just dispatched.
+          RUN_ID=""
+          for _ in $(seq 1 12); do
+            sleep 10
+            RUN_ID=$(gh api -X GET "repos/${GH_REPO}/actions/workflows/deploy-prod.yml/runs" \
+              -f event=workflow_dispatch -f "created=>=${DISPATCH_TIME}" \
+              --jq '.workflow_runs[0].id // empty')
+            [[ -n "${RUN_ID}" ]] && break
+          done
+          if [[ -z "${RUN_ID}" ]]; then
+            echo "::error::Dispatched deploy-prod.yml but could not find the resulting workflow run."
+            exit 1
+          fi
+          echo "Deploy run: https://github.com/${GH_REPO}/actions/runs/${RUN_ID}"
+          echo "RUN_ID=${RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: "Wait for Deploy to Finish"
+        env:
+          RUN_ID: ${{ steps.dispatch.outputs.RUN_ID }}
+        run: |
+          while true; do
+            STATUS=$(gh api "repos/${GH_REPO}/actions/runs/${RUN_ID}" --jq '.status')
+            [[ "${STATUS}" == "completed" ]] && break
+            echo "Deploy run ${RUN_ID} is ${STATUS}; waiting..."
+            sleep 60
+          done
+          CONCLUSION=$(gh api "repos/${GH_REPO}/actions/runs/${RUN_ID}" --jq '.conclusion')
+          echo "Deploy run ${RUN_ID} concluded: ${CONCLUSION}"
+          if [[ "${CONCLUSION}" != "success" ]]; then
+            echo "::error::Deploy failed; not creating a release. The next scheduled check will retry."
+            exit 1
+          fi
+
+      - name: "Create GitHub Release"
+        env:
+          NEXT_TAG: ${{ steps.next_tag.outputs.NEXT_TAG }}
+          TARGET_SHA: ${{ steps.next_tag.outputs.TARGET_SHA }}
+        run: |
+          if [[ -n "${PREVIOUS_VERSION}" ]]; then
+            BUMP_LINE="Bumped \`ampinstmgr\` from ${PREVIOUS_VERSION} to ${AMP_VERSION}."
+          else
+            BUMP_LINE="Bumped \`ampinstmgr\` to ${AMP_VERSION}."
+          fi
+          gh release create "${NEXT_TAG}" \
+            --target "${TARGET_SHA}" \
+            --title "${NEXT_TAG} - AMP ${AMP_VERSION}" \
+            --notes "${BUMP_LINE}
+
+          ---
+          _This release was created automatically after a new \`ampinstmgr\` version was detected in the CubeCoders repository._
+          <!-- ampinstmgr-version: ${AMP_VERSION} -->"
+
+      - name: "Write Summary"
+        env:
+          NEXT_TAG: ${{ steps.next_tag.outputs.NEXT_TAG }}
+          IMAGE: ${{ vars.DOCKERHUB_IMAGE || 'mitchtalmadge/amp-dockerized' }}
+        run: |
+          {
+            echo "## AMP Update Released"
+            echo ""
+            echo "- ampinstmgr: \`${PREVIOUS_VERSION:-<unset>}\` -> \`${AMP_VERSION}\`"
+            echo "- Release: [${NEXT_TAG}](https://github.com/${GH_REPO}/releases/tag/${NEXT_TAG})"
+            echo "- Image: \`${IMAGE}:${NEXT_TAG}\` (and \`latest\`)"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -16,13 +16,18 @@ jobs:
   build:
     uses: ./.github/workflows/build.yml
     with:
-      for_deploy: true
+      # Pushes to master only build the image (validating the merge and warming
+      # the shared build cache); only tag pushes and manual dispatches deploy.
+      # A branch push must never deploy: it has no usable tag name (GITHUB_REF
+      # would be e.g. "refs/heads/master", which is not a valid Docker tag).
+      for_deploy: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     secrets: inherit
 
   deploy:
     name: "Deploy"
     runs-on: ubuntu-latest
     needs: build
+    if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
     env:
       # Set the DOCKERHUB_IMAGE repository variable to push elsewhere (e.g. in forks).
       IMAGE: ${{ vars.DOCKERHUB_IMAGE || 'mitchtalmadge/amp-dockerized' }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -22,6 +22,9 @@ jobs:
     name: "Deploy"
     runs-on: ubuntu-latest
     needs: build
+    env:
+      # Set the DOCKERHUB_IMAGE repository variable to push elsewhere (e.g. in forks).
+      IMAGE: ${{ vars.DOCKERHUB_IMAGE || 'mitchtalmadge/amp-dockerized' }}
     steps:
       - name: "Download Docker Image Artifacts"
         uses: actions/download-artifact@v4
@@ -42,7 +45,7 @@ jobs:
           for f in $(find /tmp -type f -iname 'docker-image-*.tar' -print); do
             ARCH=$(echo ${f} | sed -E 's/.*docker-image-(.*).tar/\1/')
             docker load --input ${f}
-            TAG="mitchtalmadge/amp-dockerized:${{ steps.get_tag_name.outputs.TAG_NAME }}-${ARCH}"
+            TAG="${IMAGE}:${{ steps.get_tag_name.outputs.TAG_NAME }}-${ARCH}"
             TAGS="${TAGS} ${TAG}"
             docker tag amp-dockerized:latest ${TAG}
           done
@@ -54,10 +57,10 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: "Deploy to Docker Hub"
-        run: docker image push --all-tags mitchtalmadge/amp-dockerized
+        run: docker image push --all-tags ${IMAGE}
       - name: "Deploy Multi-Arch Manifests"
         run: |
-          MANIFESTS="mitchtalmadge/amp-dockerized:latest mitchtalmadge/amp-dockerized:${{ steps.get_tag_name.outputs.TAG_NAME }}"
+          MANIFESTS="${IMAGE}:latest ${IMAGE}:${{ steps.get_tag_name.outputs.TAG_NAME }}"
           for m in ${MANIFESTS}; do
             docker manifest create ${m} ${{ steps.load_images.outputs.TAGS }}
             docker manifest push ${m}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -17,6 +17,7 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       for_deploy: true
+    secrets: inherit
 
   deploy:
     name: "Deploy"
@@ -26,10 +27,11 @@ jobs:
       # Set the DOCKERHUB_IMAGE repository variable to push elsewhere (e.g. in forks).
       IMAGE: ${{ vars.DOCKERHUB_IMAGE || 'mitchtalmadge/amp-dockerized' }}
     steps:
-      - name: "Download Docker Image Artifacts"
+      - name: "Download Digest Artifacts"
         uses: actions/download-artifact@v4
         with:
-          path: /tmp
+          path: /tmp/digests
+          pattern: digests-*
       - name: "Get Tag Name"
         id: get_tag_name
         run: |
@@ -38,30 +40,24 @@ jobs:
           else
             echo "TAG_NAME=$(echo ${GITHUB_REF#refs/tags/})" >> $GITHUB_OUTPUT
           fi
-      - name: "Load Docker Images"
-        id: load_images
-        run: |
-          TAGS=""
-          for f in $(find /tmp -type f -iname 'docker-image-*.tar' -print); do
-            ARCH=$(echo ${f} | sed -E 's/.*docker-image-(.*).tar/\1/')
-            docker load --input ${f}
-            TAG="${IMAGE}:${{ steps.get_tag_name.outputs.TAG_NAME }}-${ARCH}"
-            TAGS="${TAGS} ${TAG}"
-            docker tag amp-dockerized:latest ${TAG}
-          done
-          echo "TAGS=${TAGS}" >> $GITHUB_OUTPUT
-          docker image ls -a
       - name: "Login to Docker Hub"
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: "Deploy to Docker Hub"
-        run: docker image push --all-tags ${IMAGE}
-      - name: "Deploy Multi-Arch Manifests"
+      - name: "Deploy Tags and Multi-Arch Manifests"
+        env:
+          TAG_NAME: ${{ steps.get_tag_name.outputs.TAG_NAME }}
         run: |
-          MANIFESTS="${IMAGE}:latest ${IMAGE}:${{ steps.get_tag_name.outputs.TAG_NAME }}"
-          for m in ${MANIFESTS}; do
-            docker manifest create ${m} ${{ steps.load_images.outputs.TAGS }}
-            docker manifest push ${m}
+          # The build workflow pushed the per-arch images by digest; assemble
+          # them into tags and manifests without pulling any image data.
+          REFS=""
+          for d in /tmp/digests/digests-*/*; do
+            ARCH=$(basename $(dirname ${d}) | sed 's/^digests-//')
+            DIGEST=$(basename ${d})
+            REFS="${REFS} ${IMAGE}@sha256:${DIGEST}"
+            # Arch-specific tag, e.g. :v27-amd64
+            docker buildx imagetools create -t "${IMAGE}:${TAG_NAME}-${ARCH}" "${IMAGE}@sha256:${DIGEST}"
           done
+          docker buildx imagetools create -t "${IMAGE}:${TAG_NAME}" -t "${IMAGE}:latest" ${REFS}
+          docker buildx imagetools inspect "${IMAGE}:${TAG_NAME}"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -22,6 +22,9 @@ jobs:
     name: "Deploy Staging"
     runs-on: ubuntu-latest
     needs: build
+    env:
+      # Set the DOCKERHUB_IMAGE repository variable to push elsewhere (e.g. in forks).
+      IMAGE: ${{ vars.DOCKERHUB_IMAGE || 'mitchtalmadge/amp-dockerized' }}
     steps:
       - name: "Download Docker Image Artifacts"
         uses: actions/download-artifact@v4
@@ -37,7 +40,7 @@ jobs:
           for f in $(find /tmp -type f -iname 'docker-image-*.tar' -print); do
             ARCH=$(echo ${f} | sed -E 's/.*docker-image-(.*).tar/\1/')
             docker load --input ${f}
-            TAG="mitchtalmadge/amp-dockerized:${{ steps.get_branch_name.outputs.BRANCH_NAME }}-${ARCH}"
+            TAG="${IMAGE}:${{ steps.get_branch_name.outputs.BRANCH_NAME }}-${ARCH}"
             TAGS="${TAGS} ${TAG}"
             docker tag amp-dockerized:latest ${TAG}
           done
@@ -49,9 +52,9 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: "Deploy to Docker Hub"
-        run: docker image push --all-tags mitchtalmadge/amp-dockerized
+        run: docker image push --all-tags ${IMAGE}
       - name: "Deploy Multi-Arch Manifest"
         run: |
-          MANIFEST="mitchtalmadge/amp-dockerized:${{ steps.get_branch_name.outputs.BRANCH_NAME }}"
+          MANIFEST="${IMAGE}:${{ steps.get_branch_name.outputs.BRANCH_NAME }}"
           docker manifest create ${MANIFEST} ${{ steps.load_images.outputs.TAGS }}
           docker manifest push ${MANIFEST}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -17,7 +17,8 @@ jobs:
     uses: ./.github/workflows/build.yml
     with:
       for_deploy: true
-  
+    secrets: inherit
+
   deploy:
     name: "Deploy Staging"
     runs-on: ubuntu-latest
@@ -26,35 +27,32 @@ jobs:
       # Set the DOCKERHUB_IMAGE repository variable to push elsewhere (e.g. in forks).
       IMAGE: ${{ vars.DOCKERHUB_IMAGE || 'mitchtalmadge/amp-dockerized' }}
     steps:
-      - name: "Download Docker Image Artifacts"
+      - name: "Download Digest Artifacts"
         uses: actions/download-artifact@v4
         with:
-          path: /tmp
+          path: /tmp/digests
+          pattern: digests-*
       - name: "Get Branch Name"
         id: get_branch_name
         run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
-      - name: "Load Docker Images"
-        id: load_images
-        run: |
-          TAGS=""
-          for f in $(find /tmp -type f -iname 'docker-image-*.tar' -print); do
-            ARCH=$(echo ${f} | sed -E 's/.*docker-image-(.*).tar/\1/')
-            docker load --input ${f}
-            TAG="${IMAGE}:${{ steps.get_branch_name.outputs.BRANCH_NAME }}-${ARCH}"
-            TAGS="${TAGS} ${TAG}"
-            docker tag amp-dockerized:latest ${TAG}
-          done
-          echo "TAGS=${TAGS}" >> $GITHUB_OUTPUT
-          docker image ls -a
       - name: "Login to Docker Hub"
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: "Deploy to Docker Hub"
-        run: docker image push --all-tags ${IMAGE}
-      - name: "Deploy Multi-Arch Manifest"
+      - name: "Deploy Tags and Multi-Arch Manifest"
+        env:
+          BRANCH_NAME: ${{ steps.get_branch_name.outputs.BRANCH_NAME }}
         run: |
-          MANIFEST="${IMAGE}:${{ steps.get_branch_name.outputs.BRANCH_NAME }}"
-          docker manifest create ${MANIFEST} ${{ steps.load_images.outputs.TAGS }}
-          docker manifest push ${MANIFEST}
+          # The build workflow pushed the per-arch images by digest; assemble
+          # them into tags and manifests without pulling any image data.
+          REFS=""
+          for d in /tmp/digests/digests-*/*; do
+            ARCH=$(basename $(dirname ${d}) | sed 's/^digests-//')
+            DIGEST=$(basename ${d})
+            REFS="${REFS} ${IMAGE}@sha256:${DIGEST}"
+            # Arch-specific tag, e.g. :staging-amd64
+            docker buildx imagetools create -t "${IMAGE}:${BRANCH_NAME}-${ARCH}" "${IMAGE}@sha256:${DIGEST}"
+          done
+          docker buildx imagetools create -t "${IMAGE}:${BRANCH_NAME}" ${REFS}
+          docker buildx imagetools inspect "${IMAGE}:${BRANCH_NAME}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     apt-transport-https \
+    dirmngr \
+    gnupg \
     jq \
+    locales \
     sed \
     tzdata \
     wget && \
@@ -36,14 +39,6 @@ RUN apt-get update && \
     /var/tmp/*
 
 # Configure Locales
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends locales && \
-    apt-get -y clean && \
-    apt-get -y autoremove --purge && \
-    rm -rf \
-    /tmp/* \
-    /var/lib/apt/lists/* \
-    /var/tmp/*
 RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales && \
     update-locale LANG=en_US.UTF-8
@@ -197,11 +192,11 @@ RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
 # Manually install ampinstmgr by extracting it from the deb package.
 # Docker doesn't have systemctl and other things that AMP's deb postinst expects,
 # so we can't use apt to install ampinstmgr.
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends \
-    dirmngr \
-    apt-transport-https \
-    gnupg
+
+# The latest ampinstmgr version, passed in by CI. Referencing it below busts the
+# build cache for this layer whenever a new version is released; without it, a
+# cached layer would silently keep shipping the old ampinstmgr.
+ARG AMP_VERSION=
 
 # Add CubeCoders repository and key.
 # Uses the deb822 .sources format and keyring location from the official
@@ -215,8 +210,9 @@ RUN install -d -m 0755 /usr/share/keyrings && \
     fi && \
     printf "Types: deb\nURIs: https://cdn-repo.c7rs.com/%s\nSuites: debian/\nArchitectures: %s\nSigned-By: /usr/share/keyrings/cdn-repo.c7rs.com.gpg\n" "${REPO_SUFFIX}" "$(dpkg --print-architecture)" > /etc/apt/sources.list.d/cdn-repo.c7rs.com.sources && \
     apt-get update && \
-    # Just download (don't actually install) ampinstmgr
-    apt-get install -y --no-install-recommends --download-only ampinstmgr && \
+    # Just download (don't actually install) ampinstmgr.
+    # Pin the version when CI provides one; fall back to the latest otherwise.
+    apt-get install -y --no-install-recommends --download-only "ampinstmgr${AMP_VERSION:+=${AMP_VERSION}}" && \
     # Extract ampinstmgr from downloaded package
     mkdir -p /tmp/ampinstmgr && \
     dpkg-deb -x /var/cache/apt/archives/ampinstmgr_*.deb /tmp/ampinstmgr && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -203,13 +203,17 @@ RUN apt-get update && \
     apt-transport-https \
     gnupg
 
-# Add CubeCoders repository and key
-RUN wget -qO - http://repo.cubecoders.com/archive.key | gpg --dearmor > /etc/apt/trusted.gpg.d/cubecoders-archive-keyring.gpg && \
+# Add CubeCoders repository and key.
+# Uses the deb822 .sources format and keyring location from the official
+# getamp.sh installer (addRepo), as required on Debian 12+.
+RUN install -d -m 0755 /usr/share/keyrings && \
+    wget -qO /usr/share/keyrings/cdn-repo.c7rs.com.gpg https://cdn-repo.c7rs.com/archive.key && \
     if [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
-        echo "deb http://repo.cubecoders.com/aarch64 debian/" > /etc/apt/sources.list.d/cubecoders.list; \
+        REPO_SUFFIX="aarch64/"; \
     else \
-        echo "deb http://repo.cubecoders.com/ debian/" > /etc/apt/sources.list.d/cubecoders.list; \
+        REPO_SUFFIX=""; \
     fi && \
+    printf "Types: deb\nURIs: https://cdn-repo.c7rs.com/%s\nSuites: debian/\nArchitectures: %s\nSigned-By: /usr/share/keyrings/cdn-repo.c7rs.com.gpg\n" "${REPO_SUFFIX}" "$(dpkg --print-architecture)" > /etc/apt/sources.list.d/cdn-repo.c7rs.com.sources && \
     apt-get update && \
     # Just download (don't actually install) ampinstmgr
     apt-get install -y --no-install-recommends --download-only ampinstmgr && \


### PR DESCRIPTION
# Automatically build new images when `ampinstmgr` updates + faster CI builds

## Auto-update workflow

- **New "Check AMP Update" workflow**: checks the CubeCoders APT repo
  daily for a new `ampinstmgr` version. When one appears, it runs the
  existing "Deploy Production" workflow with the next tag (e.g. `v27`)
  and, after a successful deploy, creates a GitHub release in the usual
  style ("v27 - AMP 2.8"). The last built version is tracked via the
  release history, so no new secrets or setup are needed.

- **Dockerfile: updated CubeCoders repo setup**: `repo.cubecoders.com`
  now redirects to `cdn-repo.c7rs.com`, and the official installer uses
  the deb822 `.sources` format on Debian 12+. The Dockerfile now matches
  the official `getamp.sh` exactly.

- **Configurable Docker Hub image name**: the deploy workflows read the
  image name from the `DOCKERHUB_IMAGE` repo variable, falling back to
  `mitchtalmadge/amp-dockerized`. No change for this repo; forks can now
  test the full pipeline with their own Docker Hub repo.

## Faster CI builds

- **Layer caching in CI**: builds now use the GitHub Actions build
  cache (scoped per architecture), so unchanged layers (Mono, Wine,
  the five JDKs, ...) are reused instead of rebuilt every run. A change
  that only touches `entrypoint/` rebuilds in a couple of minutes
  instead of 10-15. To keep the daily auto-update working, the latest
  `ampinstmgr` version is fetched before each build and passed in as a
  build-arg, which busts exactly that layer when a new version is
  released (and pins the downloaded version in CI).

- **Push by digest instead of tar artifacts**: deploy builds push the
  per-arch images directly to Docker Hub from the build job. The deploy
  job then assembles tags and multi-arch manifests with
  `docker buildx imagetools create`, a registry-side operation that
  transfers no image data. This replaces the previous flow of exporting
  the multi-GB image to a tar, uploading it as an artifact, downloading
  it, loading it, and pushing it. Published tags are unchanged
  (`vN`, `latest`, `vN-amd64`, `vN-arm64`). PR builds still run without
  any secrets, they just build with cache and push nothing. Also bumped
  `build-push-action` to v6.

- **Consolidated apt layers**: merged the small setup layers (init
  tools, locales, dirmngr/gnupg) into one, removing redundant
  `apt-get update` runs and package lists that one layer leaked into
  the image.

Tested end-to-end on my fork (build, push-by-digest, manifest
assembly, release all working).

Note: CubeCoders is currently at 2.8 while the latest release here is
v26 (2.7.2), so the first scheduled run will automatically publish 2.8
as `v27`.